### PR TITLE
Automatic update of Microsoft.AspNetCore.Hosting to 2.2.0

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,52 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
-    <ItemGroup>
-        <PackageReference Update="Marten" Version="3.6.0" />
-        <PackageReference Update="Marten.NodaTime" Version="1.1.0" />
-        <PackageReference Update="Marten.CommandLine" Version="3.6.0" />
-        <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-        <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
-        <PackageReference Update="Microsoft.Azure.WebJobs" Version="3.0.9" />
-        <PackageReference Update="Microsoft.Azure.WebJobs.Extensions" Version="3.0.2" />
-        <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="3.0.0-preview6.19304.6" />
-        <PackageReference Update="Microsoft.Extensions.Configuration" Version="3.0.0-preview6.19304.6" />
-        <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.0.0-preview6.19304.6" />
-        <PackageReference Update="NodaTime" Version="2.4.5" />
-        <PackageReference Update="NodaTime.Testing" Version="2.4.5" />
-        <PackageReference Update="NodaTime.Serialization.JsonNet" Version="2.2.0" />
-        <PackageReference Update="Npgsql" Version="4.0.7" />
-        <PackageReference Update="Npgsql.NodaTime" Version="4.0.7" />
-        <PackageReference Update="Rocket.Surgery.Builders" Version="5.0.2" />
-        <PackageReference Update="Rocket.Surgery.Conventions" Version="5.0.2" />
-        <PackageReference Update="Rocket.Surgery.Conventions.Abstractions" Version="5.0.2" />
-        <PackageReference Update="Rocket.Surgery.Domain" Version="0.6.0" />
-        <PackageReference Update="Rocket.Surgery.Extensions" Version="1.0.0" />
-        <PackageReference Update="Rocket.Surgery.Extensions.CommandLine.Abstractions" Version="4.1.1" />
-        <PackageReference Update="Rocket.Surgery.Extensions.DependencyInjection" Version="5.1.1" />
-        <PackageReference Update="Rocket.Surgery.Extensions.DependencyInjection.Abstractions" Version="5.1.1" />
-        <PackageReference Update="Rocket.Surgery.Extensions.Logging.Abstractions" Version="5.1.1" />
-        <PackageReference Update="Rocket.Surgery.Extensions.WebJobs.Abstractions" Version="5.1.1" />
-        <PackageReference Update="Rocket.Surgery.Linq.Extensions" Version="1.0.0" />
-        <PackageReference Update="Rocket.Surgery.Reactive.Extensions" Version="1.0.0" />
-        <PackageReference Update="Scrutor" Version="3.0.2" />
-        <PackageReference Update="System.Security.Claims" Version="4.3.0" />
-        <PackageReference Update="Rocket.Surgery.Extensions.Testing.Docker" Version="1.1.7" />
-        <PackageReference Update="Docker.DotNet" Version="3.125.2" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="Rocket.Surgery.Build.Metadata" Version="3.3.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Update="Rocket.Surgery.Extensions.Testing" Version="1.1.7" />
-        <PackageReference Update="Autofac.Extras.FakeItEasy" Version="5.0.1" />
-        <PackageReference Update="Bogus" Version="27.0.1" />
-        <PackageReference Update="coverlet.msbuild" Version="2.6.2" />
-        <PackageReference Update="FakeItEasy" Version="5.1.1" />
-        <PackageReference Update="FakeItEasy.Analyzer.CSharp" Version="5.1.1" />
-        <PackageReference Update="FluentAssertions" Version="5.7.0" />
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-        <PackageReference Update="xunit" Version="2.4.1" />
-        <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-        <PackageReference Update="XunitXml.TestLogger" Version="2.1.26" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Marten" Version="3.6.0" />
+    <PackageReference Update="Marten.NodaTime" Version="1.1.0" />
+    <PackageReference Update="Marten.CommandLine" Version="3.6.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Azure.WebJobs" Version="3.0.9" />
+    <PackageReference Update="Microsoft.Azure.WebJobs.Extensions" Version="3.0.2" />
+    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="3.0.0-preview6.19304.6" />
+    <PackageReference Update="Microsoft.Extensions.Configuration" Version="3.0.0-preview6.19304.6" />
+    <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.0.0-preview6.19304.6" />
+    <PackageReference Update="NodaTime" Version="2.4.5" />
+    <PackageReference Update="NodaTime.Testing" Version="2.4.5" />
+    <PackageReference Update="NodaTime.Serialization.JsonNet" Version="2.2.0" />
+    <PackageReference Update="Npgsql" Version="4.0.7" />
+    <PackageReference Update="Npgsql.NodaTime" Version="4.0.7" />
+    <PackageReference Update="Rocket.Surgery.Builders" Version="5.0.2" />
+    <PackageReference Update="Rocket.Surgery.Conventions" Version="5.0.2" />
+    <PackageReference Update="Rocket.Surgery.Conventions.Abstractions" Version="5.0.2" />
+    <PackageReference Update="Rocket.Surgery.Domain" Version="0.6.0" />
+    <PackageReference Update="Rocket.Surgery.Extensions" Version="1.0.0" />
+    <PackageReference Update="Rocket.Surgery.Extensions.CommandLine.Abstractions" Version="4.1.1" />
+    <PackageReference Update="Rocket.Surgery.Extensions.DependencyInjection" Version="5.1.1" />
+    <PackageReference Update="Rocket.Surgery.Extensions.DependencyInjection.Abstractions" Version="5.1.1" />
+    <PackageReference Update="Rocket.Surgery.Extensions.Logging.Abstractions" Version="5.1.1" />
+    <PackageReference Update="Rocket.Surgery.Extensions.WebJobs.Abstractions" Version="5.1.1" />
+    <PackageReference Update="Rocket.Surgery.Linq.Extensions" Version="1.0.0" />
+    <PackageReference Update="Rocket.Surgery.Reactive.Extensions" Version="1.0.0" />
+    <PackageReference Update="Scrutor" Version="3.0.2" />
+    <PackageReference Update="System.Security.Claims" Version="4.3.0" />
+    <PackageReference Update="Rocket.Surgery.Extensions.Testing.Docker" Version="1.1.7" />
+    <PackageReference Update="Docker.DotNet" Version="3.125.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Rocket.Surgery.Build.Metadata" Version="3.3.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Rocket.Surgery.Extensions.Testing" Version="1.1.7" />
+    <PackageReference Update="Autofac.Extras.FakeItEasy" Version="5.0.1" />
+    <PackageReference Update="Bogus" Version="27.0.1" />
+    <PackageReference Update="coverlet.msbuild" Version="2.6.2" />
+    <PackageReference Update="FakeItEasy" Version="5.1.1" />
+    <PackageReference Update="FakeItEasy.Analyzer.CSharp" Version="5.1.1" />
+    <PackageReference Update="FluentAssertions" Version="5.7.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Update="xunit" Version="2.4.1" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Update="XunitXml.TestLogger" Version="2.1.26" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.AspNetCore.Hosting` to `2.2.0` from `2.1.1`
`Microsoft.AspNetCore.Hosting 2.2.0` was published at `2018-12-03T23:11:42Z`, 6 months ago

1 project update:
Updated `Directory.Build.targets` to `Microsoft.AspNetCore.Hosting` `2.2.0` from `2.1.1`

[Microsoft.AspNetCore.Hosting 2.2.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Hosting/2.2.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
